### PR TITLE
TT-28: Add support for administrative labels to duo_layouts

### DIFF
--- a/src/Plugin/Layout/LayoutBase.php
+++ b/src/Plugin/Layout/LayoutBase.php
@@ -52,6 +52,8 @@ abstract class LayoutBase extends LayoutDefault implements PluginFormInterface {
   public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
     $form = parent::buildConfigurationForm($form, $form_state);
     $form['label']['#weight'] = -1000;
+    $form['label']['#title'] = $this->t('Administrative Label');
+    $form['label']['#description'] = $this->t('The administrative label appears only on the layout screen interface.');
 
     $form['heading'] = [
       '#type' => 'textfield',


### PR DESCRIPTION
With the release of core 8.8, layout builder now supports adding an "Administrative label" to each layout section. I updated the LayoutBase class following the example of the MultiWidthLayoutBase in core (/core/modules/layout_builder/src/Plugin/Layout/MultiWidthLayoutBase.php) so that our custom layouts would include this field in their configuration.