### PR TITLE
TT-51: Fix issue where text fields in the CKEditor dialog are not editable

### DIFF
--- a/duo_layouts.libraries.yml
+++ b/duo_layouts.libraries.yml
@@ -50,3 +50,8 @@ parallax:
     js/parallax.js: {}
   dependencies:
     - core/jquery
+ckeditor-fix:
+  js:
+    js/ckeditor-fix.js: {}
+  dependencies:
+    - core/jquery.ui.dialog

--- a/duo_layouts.module
+++ b/duo_layouts.module
@@ -40,3 +40,29 @@ function duo_layouts_plugin_filter_layout__layout_builder_alter(array &$definiti
 function duo_layouts_form_node_layout_builder_form_alter(&$form, FormStateInterface $form_state, $form_id) {
   $form['revision']['#access'] = FALSE;
 }
+
+/**
+ * Implements hook_preprocess_page().
+ */
+function duo_layouts_preprocess_page(&$variables) {
+  // Just in case library isn't defined yet, go ahead and define it.
+  if (!isset($variables['#attached']['library'])) {
+    $variables['#attached']['library'] = [];
+  }
+
+  // Add libraries.
+  if (is_array($variables['#attached']['library'])) {
+    // If the user has permission to add content, then add our script to fix
+    // issues with modals in layout builder.
+    //
+    // This is the issue:
+    // https://stackoverflow.com/questions/19570661/ckeditor-plugin-text-fields-not-editable
+    // https://www.drupal.org/project/drupal/issues/3065095
+    //
+    // This is where the final solution was found:
+    // https://stackoverflow.com/a/28086465
+    if ($variables['user']->hasPermission('access content overview')) {
+      $variables['#attached']['library'][] = 'duo_layouts/ckeditor-fix';
+    }
+  }
+}

--- a/js/ckeditor-fix.js
+++ b/js/ckeditor-fix.js
@@ -1,0 +1,15 @@
+// This snippet fixes an issue where input fields are not editable in ckeditor
+// modals within the layout builder modal. See kettering_theme_preprocess_page for
+// links to the issues.
+
+(function ($, Drupal) {
+
+  orig_allowInteraction = $.ui.dialog.prototype._allowInteraction;
+  $.ui.dialog.prototype._allowInteraction = function(event) {
+     if ($(event.target).closest('.cke_dialog').length) {
+        return true;
+     }
+     return orig_allowInteraction.apply(this, arguments);
+  };
+
+})(jQuery, Drupal);


### PR DESCRIPTION
Notification only. This is an important little fix for an issue where text fields in CKEditor dialog windows are not editable, when launched from within a layout builder modal. I applied this fix on the sites where we have layout builder enabled, so this is just a backport to duo_layouts. @jthompsonDuo I noted in the original ticket that you'll probably want to add this fix to Much, and anywhere else you have layout builder enabled.